### PR TITLE
v2.0.0 - Multi season support

### DIFF
--- a/.docker/Dockerfile_base
+++ b/.docker/Dockerfile_base
@@ -1,7 +1,7 @@
 FROM python:3.9-slim
 
 RUN useradd -m -s /bin/bash openra \
-    && apt-get update && apt-get install -y --no-install-recommends make \
+    && apt-get update && apt-get install -y --no-install-recommends make curl \
     && apt-get clean
 
 RUN mkdir /home/openra/oraladder

--- a/.docker/Dockerfile_ladder
+++ b/.docker/Dockerfile_ladder
@@ -1,7 +1,25 @@
 FROM oraladder/base:latest
 
-RUN make initladderdev
+# https://github.com/chartjs/Chart.js/releases/latest
+ENV CHART_JS_VERSION="2.9.3"
+# https://github.com/jquery/jquery/releases/latest
+ENV JQUERY_VERSION="3.6.0"
+# https://github.com/DataTables/DataTables/releases/latest
+ENV DATATABLES_VERSION="1.10.24"
 
-RUN . venv/bin/activate && pip install gunicorn
+RUN cd ladderweb/static/ \
+    && curl -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/${CHART_JS_VERSION}/Chart.min.css -o Chart.min.css \
+    && curl -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/${CHART_JS_VERSION}/Chart.bundle.min.js -o Chart.bundle.min.js \
+    && curl -L https://cdn.datatables.net/v/dt/dt-${DATATABLES_VERSION}/datatables.min.js -o datatables.min.js \
+    && curl -L https://code.jquery.com/jquery-${JQUERY_VERSION}.min.js -o jquery.min.js
+
+RUN python3 -m venv venv/
+
+RUN . venv/bin/activate && pip install gunicorn && pip install -e .
+
+RUN mkdir instance \
+    && for DB in "ra-all" "ra-2m" "td-all" "td-2m";  \
+        do venv/bin/ora-ladder -d "instance/db-${DB}.sqlite3";  \
+        done;
 
 CMD ["venv/bin/gunicorn", "-b", "0.0.0.0:8000", "ladderweb:app"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-## [2.0.0] - (date tbd)
+## [2.0.0] - 2022-10-30
 
 ### Added
 - Introduced changelog and bumped version to `2.0.0`. While this is not a release with any breaking changes, change in project organization and the number of changes since what was the initial production release merit a major release.
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added CSS/JS based UI support for responsive navbar
   - Added exposition texts to `leaderboard` [template file](ladderweb/templates/leaderboard.html)
   - Added history of player rankings across seasons to `player` page
+- Added ladder map pack [`2022.1`](ladderweb/static/ladder-map-pack-2021.1.zip); see corresponding maps on the 
+  [OpenRA resource center](https://resource.openra.net/maps/?mod=ra&category=Ladder+2022.1)
 
 ### Changed
 - Refactored handling of database selection in the `ladderweb` subproject to allow for a dynamic number of 2-month-period databases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [2.0.0] - (date tbd)
+
+### Added
+- Introduced changelog and bumped version to `2.0.0`. While this is not a release with any breaking changes, change in project organization and the number of changes since what was the initial production release merit a major release.
+- Added `start` and `end` parameters to `ora-ladder` CLI to enable database file creation for specific timeframes
+- Added CLI tool `ora-dbtool` to generate multiple 2-month-period database files in batch (basically a wrapper around the existing `ora-ladder` CLI)
+- Added configuration parameters to control behaviour of `ladderweb` website, see subproject [README file](ladderweb/README.md).
+- Added new `ladderweb` UI features:
+  - Added CSS/JS based UI support for responsive navbar
+  - Added exposition texts to `leaderboard` [template file](ladderweb/templates/leaderboard.html)
+  - Added history of player rankings across seasons to `player` page
+
+### Changed
+- Refactored handling of database selection in the `ladderweb` subproject to allow for a dynamic number of 2-month-period databases
+

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LADDER_DATABASES = instance/db-ra-all.sqlite3 \
                    instance/db-td-2m.sqlite3  \
 
 # https://github.com/chartjs/Chart.js/releases/latest
-CHART_JS_VERSION = 2.9.4
+CHART_JS_VERSION = 2.9.3
 
 # https://github.com/jquery/jquery/releases/latest
 JQUERY_VERSION = 3.6.0
@@ -47,7 +47,7 @@ ladderweb/static/jquery.min.js:
 	$(CURL) -L https://code.jquery.com/jquery-$(JQUERY_VERSION).min.js -o $@
 
 $(LADDER_DATABASES): instance
-	$(VENV)/bin/ora-ladder -d $@
+	([ -f $@ ] ||  $(VENV)/bin/ora-ladder -d $@)
 
 ragldev: initragldev
 	FLASK_APP=raglweb FLASK_ENV=development FLASK_RUN_PORT=5001 RAGLWEB_DATABASE="db-ragl.sqlite3" $(VENV)/bin/flask run

--- a/laddertools/ladder.py
+++ b/laddertools/ladder.py
@@ -20,8 +20,10 @@ import datetime
 import hashlib
 import logging
 import os.path as op
+import shutil
 import sqlite3
 from collections import UserDict
+from math import ceil
 
 from filelock import FileLock, Timeout
 
@@ -198,7 +200,7 @@ def _preprocess_period(args):
             start_month = ((today.month - 1) & ~1) + 1
             start = datetime.date(today.year, start_month, 1)
         else:
-            start = today
+            start = datetime.date(year=1990, month=1, day=1)
         end = today + datetime.timedelta(days=1)
     return {"name": args.period, "start": start, "end": end}
 
@@ -253,8 +255,11 @@ def run():
     parser.add_argument('--start')
     parser.add_argument('--end')
     parser.add_argument('--bans-file')
+    parser.add_argument('-l', '--log-level', default="WARNING")
     parser.add_argument('replays', nargs='*')
     args = parser.parse_args()
+
+    logging.basicConfig(level=args.log_level)
 
     lockfile = args.database + '.lock'
     lock = FileLock(lockfile, timeout=1)
@@ -263,3 +268,83 @@ def run():
             _main(args)
     except Timeout:
         logging.error('Another instance of this application currently holds the %s lock file.', lockfile)
+
+
+def initialize_periodic_databases():
+    """A CLI tool to create multiple database files in batch
+
+    In the current implementation, this is customized to support 2-months-periods as used by the oraladder.net website.
+    For a given timespan based on "year" and "start-month" parameters, SQLite database files get created. Each DB file
+    contains data for a 2-month period starting with every 2nd month of a year (i.e. January, March, May, ...) which
+    will be named following the pattern db-{year}-{nr}.sqlite3 where {nr} is an integer counter starting with 1 for the
+    Jan-Feb period going up to 6 for the Nov-Dec period of the given year.
+
+    If invoked with a start month that does not mark the beginning of one of these periods, it will get corrected by
+    subtracting one month so that the resulting DB files will be true to the defined format/content.
+
+    For less customized database file creation, refer to the `ora-ladder` CLI tool utilizing "start" and "end"
+    parameters.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--schema', default=op.join(op.dirname(__file__), 'ladder.sql'))
+    parser.add_argument('-r', '--ranking', choices=ranking_systems.keys(), default='trueskill')
+    parser.add_argument('--bans-file')
+    parser.add_argument('-m', '--mod', default='ra')
+    parser.add_argument('-y', '--year', type=int, default=datetime.date.today().year)
+    parser.add_argument('--start-month', type=int, default='1', help="Number between 1 and 12")
+    parser.add_argument('-l', '--log-level', default='WARNING')
+    parser.add_argument('replays', nargs='*')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=args.log_level)
+
+    # Correct to previous month for even-numbered months (February, April, ...)
+    start_month = args.start_month - (args.start_month & 1 == 0)
+
+    start_date = datetime.date(year=args.year, month=start_month, day=1)
+    season_counter = ceil(start_month/2)
+    prev_db_name = None
+
+    while True:
+        # calculate the seasons end date (start + 2 months - 1 day)
+        end_date = datetime.date(start_date.year, (start_date.month + 2) % 12, start_date.day)
+        # in case we have reached January again, update year
+        if end_date.month == 1:
+            end_date = end_date.replace(year=end_date.year + 1)
+        end_date -= datetime.timedelta(days=1)
+
+        # prepare arguments for creating the actual database files
+        db_name = f"db-{args.mod}-{start_date.year}-{season_counter}.sqlite3"
+
+        # If the first database from the batch has already been created, copy that to use it as a base for the
+        # next iteration; this reduces API calls to the OpenRA user account service
+        if prev_db_name is not None:
+            shutil.copyfile(prev_db_name, db_name)
+            logging.info(f"Copied {prev_db_name} to {db_name}")
+
+        # Track database filename for next iteration
+        prev_db_name = db_name
+
+        lockfile = db_name + '.lock'
+        args.start = str(start_date)
+        args.end = str(end_date)
+        args.database = db_name
+        args.period = ""
+
+        # create the actual database files using _main() method
+        try:
+            with FileLock(lockfile, timeout=1):
+                _main(args)
+                logging.info(f"Created database file {db_name} using "
+                             f"start date {start_date}, end date {end_date}, source "
+                             f"folder {args.replays}.")
+        except Timeout:
+            logging.error('Another instance of this application currently holds the %s lock file.', lockfile)
+
+        #
+        start_date = start_date.replace(month=(start_date.month + 2) % 12)
+        season_counter += 1
+
+        # stop the loop if we completed a year or if the start date is in the future
+        if start_date.month == 1 or start_date > datetime.date.today():
+            break

--- a/laddertools/utils.py
+++ b/laddertools/utils.py
@@ -19,8 +19,7 @@ import re
 import os
 import os.path as op
 import logging
-from datetime import date
-from typing import Union
+from typing import Optional
 from urllib.request import urlopen
 
 from . import miniyaml, replay
@@ -87,7 +86,7 @@ def _parse_replay(results, accounts_db, filename):
         logging.info(f'{op.basename(filename)}: recorded')
 
 
-def _filter_period(results, period_dict: Union[dict, None]):
+def _filter_period(results, period_dict: Optional[dict]):
     if period_dict is None:
         return results
     start = period_dict["start"]
@@ -95,7 +94,7 @@ def _filter_period(results, period_dict: Union[dict, None]):
     return [r for r in results if (start <= r.end_time.date() <= end)]
 
 
-def get_results(accounts_db, replays, period_dict: Union[dict, None] = None):
+def get_results(accounts_db, replays, period_dict: Optional[dict] = None):
     results = []
     for filename in replays:
         if op.isdir(filename):

--- a/ladderweb/README.md
+++ b/ladderweb/README.md
@@ -1,0 +1,33 @@
+# OpenRA Competitive Ladder Website
+
+Flask-based web interface to display leaderboard and results information about OpenRA
+competitive games.
+
+## Configuration
+
+### Multi-Season Support
+
+The current version supports 2-month periods/seasons. By default, the application
+expects to host two seasons of each of the mods (Red Alert, Tiberian Dawn): one
+ongoing all-time season and one current 2-month season. 2-month seasons are expected to
+start on the first day of every second month, i.e. January, March, May, etc.
+
+Handling and display of more (historic) 2-month seasons is possible:
+
+* `LADDER_SEASONS_START_YEAR`,`LADDER_SEASONS_START_MONTH`: Will be used on application
+  startup to determine possible historic 2-month seasons.
+    * Based on starting year and month, seasons with the following ID schema will be 
+      supported: `YYYY-n` e.g. `2022-1` for the January-February period of 2022, 
+      `2021-6` for the Nov-Dec period of 2021 etc.
+    * SQLite database files are required to be separately generated (i.e. by using the
+      project's `ora-ladder` or `ora-dbtools` command line tools)
+    * SQLite database files must be named accordingly, `db-{mod}-{season_id}.sqlite3`,
+      e.g. `db-ra-2022-1.sqlite3` for the `2022-1` season.
+    * Parameters default to the current year / first month respectively.
+    * The configuration parameters can be set as operating system environment variables 
+      requiring `FLASK_` prefix, i.e.
+      * `FLASK_LADDER_SEASONS_START_YEAR` (defaults to current year)
+      * `FLASK_LADDER_SEASONS_START_MONTH` (defaults to `1`)
+* `LADDER_DEFAULT_SEASON_KEY`: Can be used to override the default season displayed 
+  when the website is accessed initially. Defaults to `2m` which is the key for the 
+  currently running 2-month period season. Set to `all` for all-time ranking.

--- a/ladderweb/mods.py
+++ b/ladderweb/mods.py
@@ -7,6 +7,45 @@ mods = dict(
         supports_analysis=True,
         mappacks=(
             dict(
+                label='2022.1 (2022-10-30)',
+                filename='ladder-map-pack-2022.1.zip',
+                changelog='''
+                    The 2022.1 map pack is an updated version that adds the latest 
+                    <a href="https://github.com/tttppp/ora-balance-iteration/blob/master/CHANGELOG.md#35">Balance Iteration 3.5</a> 
+                    and RAGL Season 13 maps to the selection.
+                ''',
+                maps=(
+                    ('Abendland', 'Pinkthoth'),
+                    ('Agita', 'kazu'),
+                    ('Anar', 'Pinkthoth'),
+                    ('Argon', 'kazu'),
+                    ('Assault', 'Lad'),
+                    ('Barentsøya (BB)', 'Lucian'),
+                    ('Bucharest', 'poop'),
+                    ('Circulate', 'i like men'),
+                    ('Cog of War', 'netnazgul'),
+                    ('Dirge', 'Pinkthoth'),
+                    ('Discovery', 'Lad'),
+                    ('Elevation', 'i like men'),
+                    ('Fairyland', 'Lad'),
+                    ('Forgotten Plains', 'Eskimo'),
+                    ('Greener Pastures', 'Lad'),
+                    ('Infection', 'wippie'),
+                    ('Isle of Wight', 'Lad'),
+                    ('Krakow', 'poop'),
+                    ('Moonopoly', 'Lad'),
+                    ('Overkill', 'MegaTank'),
+                    ('Pity Light', 'Widow'),
+                    ('Race Tracks', 'Blackened'),
+                    ('Scorched Earth', 'J MegaTank'),
+                    ('Sompio', 'Pinkthoth'),
+                    ('Sun Struggle', 'Lad'),
+                    ('Territorial', 'Lad'),
+                    ('Trapped', 'Blackened'),
+                    ('Yukon Territory', 'wippie'),
+                ),
+            ),
+            dict(
                 label='2022.0 (2022-01-07)',
                 filename='ladder-map-pack-2022.0.zip',
                 changelog='''

--- a/ladderweb/seasons.py
+++ b/ladderweb/seasons.py
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2020-2022
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import calendar
+import datetime
+from math import ceil
+
+seasons_default = {
+    "ra": {
+        "all": "db-ra-all.sqlite3",
+        "2m": "db-ra-2m.sqlite3"
+    },
+    "td": {
+        "all": "db-td-all.sqlite3",
+        "2m": "db-td-2m.sqlite3",
+    }
+}
+
+
+def fill_yearly_seasons(seasons_dict=None,
+                        start_year: int = datetime.date.today().year,
+                        start_month: int = 1) -> dict:
+    """Generate additional season entries based on 2-month periods
+
+    Returns a populated dictionary with mod-ID keys (ra, td) at the top level and
+    season identifiers as sub keys in descending order latest to earliest
+    (e.g. 2022-6, 2022-5, ...); value of the season identifier key is always the
+    expected SQLite database file name.
+
+    Current period will always be identified as "2m".
+
+    Database files have to be generated separately at the moment.
+
+    Example:
+
+    {
+        "ra": {
+            "all": "db-ra-all.sqlite3",
+            "2m": "db-ra-2m.sqlite3",
+            "2022-2": "db-ra-2022-2.sqlite3",
+            "2022-1": "db-ra-2022-1.sqlite3",
+            "2021-6": "db-ra-2021-6.sqlite3",
+        },
+        "td": {
+            "all": "db-td-all.sqlite3",
+            "2m": "db-td-2m.sqlite3",
+            "2022-2": "db-td-2022-2.sqlite3",
+            "2022-1": "db-td-2022-1.sqlite3",
+            "2021-6": "db-td-2021-6.sqlite3",
+        }
+    }
+
+    """
+    if seasons_dict is None:
+        seasons_dict = seasons_default
+
+    # initialize variables
+    today = datetime.date.today()
+    current_month, current_year = today.month, today.year
+    season_number = ceil(start_month / 2)
+    season_year = start_year
+    seasons = []
+
+    while True:
+        seasons.append((season_year, season_number))
+        season_number += 1
+        # omit the currently running season
+        if season_year == current_year \
+                and season_number * 2 >= current_month:
+            break
+        # increase year if we reach the 7th 2-month period
+        if season_number == 7:
+            season_year += 1
+            season_number = 1
+
+    # sort the seasons in descending chronological order, latest to earliest
+    seasons.reverse()
+
+    # put together the dictionary
+    for year, season_number in seasons:
+        for mod in ["ra", "td"]:
+            season_name = f"{year}-{season_number}"
+            db_file = f"db-{mod}-{year}-{season_number}.sqlite3"
+            seasons_dict[mod][season_name] = db_file
+
+    return seasons_dict
+
+
+def get_season_info(season_string: str):
+    """Returns display information based on a season-ID string
+
+    Input may be '2m' for the current season or any valid combination
+    of year/season-number e.g. '2022-1', '2021-5', ...
+
+    Returns a dictionary containing start and end dates as datetime.date objects and
+    a human-readable string explaining the duration
+    """
+    if season_string in ["all", "2m"]:
+        today = datetime.date.today()
+        year, season_number = today.year, ceil(today.month / 2)
+        title = 'All time' if season_string == 'all' else 'Current season'
+    else:
+        year, season_number = season_string.split("-")
+        title = season_string
+    year = int(year)
+    end_month = int(season_number) * 2
+    start_month = end_month - 1
+    _, end_day = calendar.monthrange(year, end_month)
+    return dict(
+        title=title,
+        id=season_string,
+        start=datetime.date(year, start_month, 1),
+        end=datetime.date(year, end_month, end_day),
+        duration='2 months',
+    )

--- a/ladderweb/static/nav.css
+++ b/ladderweb/static/nav.css
@@ -1,0 +1,143 @@
+/*
+CSS stylesheet for navigation bar
+
+Based on example from w3schools.org, see https://www.w3schools.com/howto/howto_js_responsive_navbar_dropdown.asp
+*/
+
+.topnav {
+    overflow: hidden;
+}
+
+/* Style the links inside the navigation bar */
+.topnav a {
+    overflow: hidden;
+    background-color: var(--color_content);
+    display: block;
+    color: white;
+    padding: 14px 16px;
+    text-decoration: none;
+    font-weight: bold;
+    float: left;
+    font-size: 17px;
+}
+
+/* Add an active class to highlight the current page */
+.active {
+	background-color: var(--color_hl);
+}
+
+/* Hide the link that should open and close the topnav on small screens */
+.topnav .icon {
+    display: none;
+    font-size: 32px
+}
+
+/* Dropdown container - needed to position the dropdown content */
+.dropdown {
+    float: left;
+    overflow: hidden;
+}
+
+/* Style the dropdown button to fit inside the topnav */
+.dropdown .dropbtn {
+    font-size: 17px;
+    font-weight: bold;
+    border: none;
+    outline: none;
+    color: white;
+    padding-left: 14px;
+    padding-top: 16px;
+    background-color: inherit;
+    font-family: inherit;
+    margin: 0;
+}
+
+button.dropbtn.with_icon {
+	background-repeat: no-repeat;
+	background-position: right bottom;
+	padding-right: 46px;
+}
+
+/* Style the dropdown content (hidden by default) */
+.dropdown-content {
+    display: none;
+    position: absolute;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+
+/* Style the links inside the dropdown */
+.dropdown-content a {
+    text-decoration: none;
+    text-align: left;
+    overflow: hidden;
+    background-color: var(--color_content);
+    display: block;
+    color: white;
+    padding: 14px 16px;
+    text-decoration: none;
+    font-weight: bold;
+    float: none;
+    font-size: 17px;
+}
+
+/* Add a dark background on topnav links and the dropdown button on hover */
+.topnav a:hover, .dropdown:hover .dropbtn {
+	color: var(--color_light0);
+}
+
+/* Add a grey background to dropdown links on hover */
+.dropdown-content a:hover {
+	background-color: var(--color_hl);
+}
+
+/* Add a grey background to dropdown links on hover */
+.dropdown-content a.active {
+	background-color: var(--color_hl);
+}
+
+.dropdown-content a.with_icon {
+	background-repeat: no-repeat;
+	background-position: left center;
+	padding-top: 22px;
+	padding-left: 42px;
+}
+
+/* Show the dropdown menu when the user moves the mouse over the dropdown button */
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+/* When the screen is less than 800 pixels wide, hide all links, except for the first one ("Home"). Show the link that contains should open and close the topnav (.icon) */
+@media screen and (max-width: 800px) {
+    .topnav a:not(:first-child), .dropdown .dropbtn {
+        display: none;
+    }
+    .topnav a.icon {
+        float: right;
+        display: block;
+    }
+}
+
+/* The "responsive" class is added to the topnav with JavaScript when the user clicks on the icon. This class makes the topnav look good on small screens (display the links vertically instead of horizontally) */
+@media screen and (max-width: 800px) {
+    .topnav.responsive {position: relative;}
+    .topnav.responsive a.icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
+    .topnav.responsive a {
+        float: none;
+        display: block;
+        text-align: left;
+    }
+    .topnav.responsive .dropdown {float: none;}
+    .topnav.responsive .dropdown-content {position: relative;}
+    .topnav.responsive .dropdown .dropbtn {
+        display: block;
+        width: 100%;
+        text-align: left;
+    }
+}

--- a/ladderweb/static/nav.js
+++ b/ladderweb/static/nav.js
@@ -1,0 +1,15 @@
+/*
+JaveScript functions for navigation bar
+
+Based on example from w3schools.org, see https://www.w3schools.com/howto/howto_js_responsive_navbar_dropdown.asp
+*/
+
+/* Toggle between adding and removing the "responsive" class to topnav when the user clicks on the icon */
+function toggle_navbar_menu() {
+  var x = document.getElementById("main_menu");
+  if (x.className === "topnav") {
+    x.className += " responsive";
+  } else {
+    x.className = "topnav";
+  }
+}

--- a/ladderweb/static/style.css
+++ b/ladderweb/static/style.css
@@ -51,6 +51,11 @@ h1 {
 
 h2 {
 	border-bottom: 1px solid;
+	margin-top: 2.5em;
+}
+
+h3 {
+	margin-top: 1.5em;
 }
 
 table tbody tr:nth-child(odd) {
@@ -106,6 +111,7 @@ table tbody td.map {
 
 img.avatar {
 	float: right;
+	margin: 4px;
 }
 
 span.diffup   { font-weight: bold; color: #72ff72; }

--- a/ladderweb/templates/base.html
+++ b/ladderweb/templates/base.html
@@ -5,25 +5,36 @@
 	<meta name="viewport" content="width=device-width" />
 	<link rel="stylesheet" href="{{ url_for('static', filename='Chart.min.css') }}">
 	<link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+	<link rel="stylesheet" href="{{ url_for('static', filename='nav.css') }}">
 	<script type="text/javascript" src="{{ url_for('static', filename='Chart.bundle.min.js') }}"></script>
 	<script type="text/javascript" src="{{ url_for('static', filename='jquery.min.js') }}"></script>
 	<script type="text/javascript" src="{{ url_for('static', filename='datatables.min.js') }}"></script>
 	<script type="text/javascript" src="{{ url_for('static', filename='dtfuncs.js') }}"></script>
+	<script type="text/javascript" src="{{ url_for('static', filename='nav.js') }}"></script>
 </head>
 <header>
 	<h1>OpenRA 1v1 Ladder</h1>
 </header>
+ <div class="topnav" id="main_menu">
 {%- for menu_id, pages in navbar_menu.items() %}
-<nav id=menu_{{ menu_id }}>
-	<ul>
+	 {% if menu_id != "pages" %}
+	  <div class="dropdown">
+		<button {% if menu_id == "mods" %}class="dropbtn with_icon" style="background-image:url('static/icon-{{ mod_id }}.png')"{% else %}class="dropbtn"{% endif %}" >&#9660; {% if menu_id=="mods" %}Mod{% else %}Season{% endif %}
+		  <i class="fa fa-caret-down"></i>
+		</button>
+		<div class="dropdown-content">
+	{% endif %}
 		{%- for menu_entry in pages %}
-		<li{% if menu_entry.active %} class=active{% endif %}>
-			<a
-				{%- if menu_entry.icon %} class="with_icon" style="background-image:url('{{ menu_entry.icon }}')"{% endif %}
+			<a class="{% if menu_entry.active %}active{% endif %}{%- if menu_entry.icon %} with_icon{% endif %}"
+				{%- if menu_entry.icon %} style="background-image:url('{{ menu_entry.icon }}')"{% endif %}
 				href="{{ menu_entry.url }}">{{ menu_entry.caption }}</a>
-		</li>
 		{%- endfor %}
-	</ul>
-</nav>
+
+	 {% if menu_id != "pages" %}
+  </div>
+  </div>
+	{% endif %}
 {%- endfor %}
+  <a href="javascript:void(0);" class="icon" onclick="toggle_navbar_menu()">&#9776;</a>
+</div>
 {% block content %}{% endblock %}

--- a/ladderweb/templates/globalstats.html
+++ b/ladderweb/templates/globalstats.html
@@ -3,6 +3,14 @@
 {% block title %}Global stats{% endblock %}
 
 {% block content %}
+{% if period_info %}
+	<div>
+		<p>
+			<strong>Selected Period</strong>: from <strong>{{ period_info.start }}</strong>
+			to <strong>{{ period_info.end }}</strong> ({{ period_info.duration }})
+		</p>
+	</div>
+{% endif %}
 <h2>Misc</h2>
 <dl>
 	<dt>Games:</dt><dd>{{ nb_games }}</dd>

--- a/ladderweb/templates/info.html
+++ b/ladderweb/templates/info.html
@@ -7,11 +7,18 @@
 <dl>
 	<dt>Map pack:</dt><dd><a href="{{ url_for('static', filename=mod.mappacks[0].filename) }}">{{ mod.mappacks[0].label }}</a></dd>
 	<dt>Compatible game version:</dt><dd><a href="{{ mod.url }}">{{ mod.release }}</a></dd>
-	<dt>Game server instances:</dt><dd>|oraladder.net| Competitive 1v1 Ladder Server <i>N</i></dd>
-	<dt>Current period:</dt><dd>from <strong>{{ period_info.start }}</strong> to <strong>{{ period_info.end }}</strong> ({{ period_info.duration }})</dd>
+	<dt>Game server instances:</dt><dd><strong>|oraladder.net| Competitive 1v1 Ladder Server <i>N</i></strong>
+	<br>Any games played on one of these servers will be recorded for the OpenRA Ladder ranking.
+        </dd>
+	<dt>Current period:</dt><dd>from <strong>{{ period_info.start }}</strong> to <strong>{{ period_info.end }}</strong>
+	    ({{ period_info.duration }})</dd>
 	<dt>Ranking algorithm:</dt><dd><a href="https://en.wikipedia.org/wiki/TrueSkill">Trueskill™</a></dd>
-	<dt>Source code:</dt><dd><a href="https://github.com/ubitux/oraladder">oraladder on Github</a></dd>
-	<dt>Contact:</dt><dd><strong>bµg</strong> on the official OpenRA Discord server</dd>
+	<dt>Source code:</dt><dd><a href="https://github.com/suhrm1/oraladder">oraladder on Github</a></dd>
+	<dt>Contact:</dt>
+	    <dd>You can reach the admin team through the <i>ladder</i> channel on the
+			<a href="https://discord.gg/JyHZFbw">OpenRA Competitive community Discord server</a></dd>
+		<dd>The ladder website and game servers are managed by <strong>milkman</strong> on the aforementioned
+			Competitive or the official <a href="https://discord.openra.net/">OpenRA Discord</a> servers</dd>
 </dl>
 <h2 id="faq">F.A.Q</h2>
 <dl id=faq>
@@ -22,7 +29,9 @@
 		join the ladder game server lobbies (see <strong>The
 		essentials</strong> section). Every game you play on these servers will
 		automatically be recorded and your score adjusted on this website within
-		minutes.
+		minutes.<br>
+		Games are limited to maps contained in the the
+		<a href="{{ url_for('static', filename=mod.mappacks[0].filename) }}">current Ladder map pack</a>.
 	</dd>
 
 	<dt>
@@ -42,7 +51,7 @@
 		Discord</a>. The former will provide many resources, while the latter
 		is full of highly competitive, passionate (and sometimes
 		friendly) players discussing different facets of the game. You
-		may also want to join the <a href="https://discord.openra.net">Official Discord</a>.
+		may also want to join the <a href="https://discord.openra.net">Official OpenRA Discord</a>.
 	</dd>
 
 	<dt>
@@ -74,6 +83,17 @@
 		level yet. The variation in your score will stabilize the more
 		you play, and become more predictable as your level becomes
 		more certain to the system.
+	</dd>
+
+	<dt>I have played my first games on the ladder server, why does
+		my name not show up in the rankings?</dt>
+	<dd>
+		The scoreboards currently only display players with a <i>positive</i> rating
+		assigned by the algorithm. Check if your games show up in the
+		"latest games" section. If you click on your player profile name, you can check
+		the rating assigned to your profile. If you are actually ranked with a negative
+		rating, keep on playing. As soon as you take your first victories, the rating
+		will rise and your journey on the ladder begins.
 	</dd>
 
 	<dt>A player is abusing the game or doing illegal activities, what can I do?</dt>

--- a/ladderweb/templates/latest.html
+++ b/ladderweb/templates/latest.html
@@ -3,6 +3,14 @@
 {% block title %}Latest games{% endblock %}
 
 {% block content %}
+{% if period_info %}
+	<div>
+		<p>
+			<strong>Selected Period</strong>: from <strong>{{ period_info.start }}</strong>
+			to <strong>{{ period_info.end }}</strong> ({{ period_info.duration }})
+		</p>
+	</div>
+{% endif %}
 <table id="latest-table">
 	<thead>
 		<tr>

--- a/ladderweb/templates/leaderboard.html
+++ b/ladderweb/templates/leaderboard.html
@@ -3,11 +3,40 @@
 {% block title %}Leaderboard{% endblock %}
 
 {% block content %}
-{% if period_info %}
-<p>
-	<strong>Current Period</strong>: from <strong>{{ period_info.start }}</strong> to <strong>{{ period_info.end }}</strong> ({{ period_info.duration }})
-</p>
-{% endif %}
+<div>
+	<p>
+		The <strong>OpenRA Competitive Multiplayer Ladder</strong> is an automated result
+		capture and ranking system for 1v1 online games.
+		<a href="{{ url_for('info', mod=mod_id) }}">Click here</a> for more information on how this works
+		and how you can join.
+	</p>
+	{% if period_info %}
+		{% if period_info.id == "2m" %}
+		<p>
+			The ranking below is the current season leaderboard. This leaderboard
+			only takes into account games played within the ongoing 2-month period. At the end of
+			each season, rankings get stored and the race for who will be the new champion
+			begins again.
+		</p>
+		<p>
+			Results from all games played across seasons get recorded into the
+			<a href="{{ url_for('leaderboard', period='all', mod=mod_id) }}">all-time ranking</a>
+			which indicates who may be the strongest players to have competed on the OpenRA
+			ladder servers.
+		</p>
+		{% endif %}
+		<p>
+			<strong>Selected Period</strong>: from <strong>{{ period_info.start }}</strong>
+			to <strong>{{ period_info.end }}</strong> ({{ period_info.duration }})
+		</p>
+	{% else %}
+	<p>
+		The <strong>all-time ranking</strong> below contains results from all games
+		played across seasons. The ranking indicates who may be the strongest players
+		to have competed on the OpenRA ladder servers.
+	</p>
+	{% endif %}
+</div>
 <table id="leaderboard-table">
 	<thead>
 		<tr>

--- a/ladderweb/templates/player.html
+++ b/ladderweb/templates/player.html
@@ -5,15 +5,108 @@
 {% block content %}
 <h2>{{ player.profile_name }}</h2>
 {%if player.avatar_url %}<img class="avatar" src="{{ player.avatar_url }}" alt="{{ player.profile_name }}">{%endif%}
-<dl>
-	<dt>Rank</dt><dd>#{{ player.rank }}</dd>
-	<dt>Rating</dt><dd>{{ player.rating }}</dd>
-	<dt>Wins</dt><dd>{{ player.wins }}</dd>
-	<dt>Losses</dt><dd>{{ player.losses }}</dd>
-	<dt>Average game duration</dt><dd>{{ player.avg_game_duration }}</dd>
-</dl>
+<p><strong>{{ player.profile_name }}</strong> has played {{ player.wins + player.losses }} games since
+	{{ player.first_game[:10] }}. They have won {{ player.wins }} games during
+	{{ (player.seasons | count)-1 }} seasons to reach their current all-time rank of
+	{{ player.rank }} at {{ player.rating }} points.</p>
+<p>Their games have lasted
+	{{ player.avg_game_duration }} minutes on average. {{ player.profile_name }} has
+	last played a game on ladder servers on {{ player.last_game[:10] }}</p>
 
-<h2>Rating evolution</h2>
+<h3>Alltime statistics</h3>
+<table id="player-alltime-info">
+	<thead>
+	<tr>
+		<th>Games</th>
+		<th>Wins</th>
+		<th>Losses</th>
+		<th>Avg. duration</th>
+		<th>Ladder debut</th>
+		<th>Latest game played</th>
+		<th>Seasons played</th>
+	</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>{{ player.wins + player.losses }}</td>
+		<td>{{ player.wins }}</td>
+		<td>{{ player.losses }}</td>
+		<td>{{ player.avg_game_duration }}</td>
+		<td>{{ player.first_game[:10] }}</td>
+		<td>{{ player.last_game[:10] }}</td>
+		<td>{{ (player.seasons | count)-1 }}</td>
+	</tr>
+	</tbody>
+</table>
+<h3>Rankings</h3>
+<table id="player-rankings">
+	<thead>
+	<tr>
+		<th>Season</th>
+		<th>Rank</th>
+		<th>Rating</th>
+		<th>Played</th>
+		<th>Wins</th>
+		<th>Losses</th>
+		<th>Win rate</th>
+		<th>Avg. game duration</th>
+	</tr>
+	</thead>
+	<tbody>
+	{% for season in player.seasons %}
+	<tr {% if season.season.id== season_info.id %}style="font-weight: bold;" {% endif %}>
+		<td {% if season.season.id !='all' %}
+			   title="{{ season.season.duration }} from {{ season.season.start }} until {{ season.season.end }}"
+			   {% endif %}>
+			<a href="{{ url_for('player', profile_id=player.profile_id, period=season.season.id) }}">{{ season.season.title }}</a></td>
+		<td>{% if season.trophy %}{{ season.trophy }}{% else %}{{ season.rank }}{% endif %}</td>
+		<td>{{ season.rating }}</td>
+		<td>{{ season.games }}</td>
+		<td>{{ season.wins }}</td>
+		<td>{{ season.losses }}</td>
+		<td>{{ season.ratio }}</td>
+		<td>{{ season.avg_game_duration }}</td>
+	</tr>
+	{% endfor %}
+	</tbody>
+</table>
+
+<h2>Season statistics: {{ season_info.title }}</h2>
+
+<h3>Latest games</h3>
+<table id="latest-player-games-table">
+	<thead>
+	<tr>
+		<th>Date</th>
+		<th>Opponent</th>
+		<th>Map</th>
+		<th>Outcome</th>
+		<th>Duration</th>
+		<th>Replay</th>
+	</tr>
+	</thead>
+</table>
+<script>
+$(document).ready(
+	function () {
+		$('#latest-player-games-table').DataTable({
+			ajax: { url: "{{ ajax_url|safe }}", dataSrc:"" },
+			columns: [
+				{ data: 'date' },
+				{ data: 'opponent', className: 'player', render: player_render },
+				{ data: 'map', className: 'map' },
+				{ data: 'outcome', render: outcome_render },
+				{ data: 'duration' },
+				{ data: 'replay', render: replay_render },
+			],
+			bSort: false,
+		});
+	}
+);
+
+</script>
+
+<h3>Rating evolution</h3>
 {%if rating_stats.data %}
 <canvas id="rating_chart"></canvas>
 <script>
@@ -36,7 +129,7 @@
 <p>Not enough data points</p>
 {%endif%}
 
-<h2>Preferred factions</h2>
+<h3>Preferred factions</h3>
 <canvas id="faction_chart"></canvas>
 <script>
 	Chart.defaults.global.defaultFontColor = "#e8e8e8";
@@ -66,7 +159,7 @@
 	});
 </script>
 
-<h2>Map performances</h2>
+<h3>Map performances</h3>
 <canvas id="playermaps_chart"></canvas>
 <script>
 	Chart.defaults.global.defaultFontColor = "#e8e8e8";
@@ -88,37 +181,5 @@
 			}]
 		}
 	});
-</script>
-
-<h2>Latest games</h2>
-<table id="latest-player-games-table">
-	<thead>
-		<tr>
-			<th>Date</th>
-			<th>Opponent</th>
-			<th>Map</th>
-			<th>Outcome</th>
-			<th>Duration</th>
-			<th>Replay</th>
-		</tr>
-	</thead>
-</table>
-<script>
-$(document).ready(
-	function () {
-		$('#latest-player-games-table').DataTable({
-			ajax: { url: "{{ ajax_url|safe }}", dataSrc:"" },
-			columns: [
-				{ data: 'date' },
-				{ data: 'opponent', className: 'player', render: player_render },
-				{ data: 'map', className: 'map' },
-				{ data: 'outcome', render: outcome_render },
-				{ data: 'duration' },
-				{ data: 'replay', render: replay_render },
-			],
-			bSort: false,
-		});
-	}
-);
 </script>
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     entry_points=dict(
         console_scripts=[
             'ora-ladder = laddertools.ladder:run',
+            'ora-dbtool  = laddertools.ladder:initialize_periodic_databases',
             'ora-mapstool = laddertools.mapstool:run',
             'ora-ragl   = laddertools.ragl:run',
             'ora-replay = laddertools.replay:run',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='oraladder',
-    version='0.1',
+    version='2.0.0',
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Adds basic support for the display of more than the current 2-month period. Check the contained README

* adds a CLI tool `ora-dbtool` to generated multiple 2-month-period database files in batch (basically a wrapper around the `ora-ladder` CLI)
  * adds `start` and `end` parameters to `ora-ladder` CLI to enable db file creation for specific timeframes 
* refactors handling of database selection in the `ladderweb` subproject (Flask UI for the ladder website) to allow for a dynamic number of 2-month-period databases
* adds CSS/JS based UI support for responsive navbar

Many of these changes are currently very specific for the 2-month-periods schema used at oraladder.net - i.e. default database filenames, seasons starting on the first of all odd-numbered months etc.. A more generic implementation may be useful in the future.