### PR TITLE
Added OpenRA ladder game server Dockerfile and utilities

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,8 +1,8 @@
 ## Docker
 
 The entire architecture can be set up in containerized environment using Docker images.
-The following instructions do not include the OpenRA game servers, only the web 
-servers.
+
+The following instructions only cover the Ladder and tournament website services. If you want to run an OpenRA game server with additional convenience features, check out the [game server docs](./ladder_server/README.md).
 
 These instructions expect you to know the basics of Docker and the Docker CLI.
 

--- a/.docker/ladder_server/Dockerfile
+++ b/.docker/ladder_server/Dockerfile
@@ -1,0 +1,21 @@
+FROM rmoriz/openra
+
+USER root
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y python3 python3-pip && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+COPY entrypoint.sh /home/openra/lib/openra/
+COPY server.sh /home/openra/lib/openra/
+
+RUN chmod +x /home/openra/lib/openra/entrypoint.sh \
+    && chmod +x /home/openra/lib/openra/server.sh \
+    && chown -R openra: /home/openra/lib/openra/
+
+USER openra
+
+COPY srvwrap_minimal.py /home/openra/lib/openra/
+
+RUN touch /home/openra/banned_profiles
+
+CMD [ "/home/openra/lib/openra/entrypoint.sh" ]

--- a/.docker/ladder_server/README.md
+++ b/.docker/ladder_server/README.md
@@ -1,0 +1,50 @@
+# OpenRA Ladder Game Server Dockerfile
+
+This [Dockerfile](./Dockerfile) extends the base image created by [rmoriz](https://github.com/rmoriz/openra-dockerfile), `rmoriz/openra` on [Docker Hub](https://hub.docker.com/r/rmoriz/openra/).
+
+Building this image updates operating system packages to current versions and adds a couple of utilities useful for running Ladder game servers:
+
+- OpenRA lobby settings get pinned to the default competitive multiplayer values (see `_overrides` dictionary in [`srvwrap_minimal.py`](./srvwrap_minimal.py)).
+- Banned OpenRA forum accounts are loaded from a file (which must contain one profile ID per line). The bans-file can be configured via the environment variable `BANS_FILE`. Default path is `/home/openra/banned_profiles`.
+- Custom game server launch script [`server.sh`](./server.sh) rotates the starting map as a random pick from the available map folder.
+
+## Usage
+
+### Building the Docker Image
+
+In this directory run `docker build`:
+
+`docker build . -t oraladder/server:latest`
+
+### Running the Game Server
+
+Minimal command to run a game server is
+
+`docker run -p 1234:1234 -e Mod=ra oraladder/server:latest`
+
+In production settings, more sophisticated scaffolding is necessary to synchronise replay folders. The following example may serve as a base for such a setup:
+
+```shell
+RELEASE=release-20210321
+docker run -dit \
+    -p $PORT:$PORT \
+    -e Name="Competitive 1v1 Ladder Server" \
+    -e RequireAuthentication=True \
+    -e EnableSingleplayer=False \
+    -e RecordReplays=True \
+    -e Mod=$MOD \
+    -e ListenPort="$PORT" \
+    -e TZ=UTC \
+    -v ./replays/:/home/openra/.openra/Replays/$MOD/$RELEASE/:rw \
+    -v ./maps/$MOD/:/home/openra/lib/openra/mods/$MOD/maps/:rw \
+    -v ./banned_profiles:/home/openra/banned_profiles:ro \
+    --add-host="resource.openra.net:127.0.0.99" \
+    --restart always \
+    --name openra_server \
+    oraladder/server:latest
+docker exec -it -u root openra_server sh -c "chown openra: -R /home/openra/.openra/"
+```
+
+Notably, `--add-host="resource.openra.net:127.0.0.99"` prevents the game server to download maps from the OpenRA Resource Center, effectively locking the map pool to what is locally available in the `maps` directory.
+
+Mod can be switched between Red Alert and Tiberian Dawn by setting the environment variable `Mod=ra` or `Mod=cnc` (NB: not `td`!).

--- a/.docker/ladder_server/entrypoint.sh
+++ b/.docker/ladder_server/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Apply patches to server settings
+python3 -c "from srvwrap_minimal import patch; patch()"
+echo "Server settings patched."
+
+# Read banned profile IDs from /home/openra/banned_profiles
+BANS_FILE="/home/openra/banned_profiles"
+BANS=$(python3 -c "from srvwrap_minimal import apply_bans; apply_bans(\"$BANS_FILE\")")
+ProfileIDBlacklist=$BANS
+export ProfileIDBlacklist
+echo "Banned profiles: ${ProfileIDBlacklist:-}"
+
+echo "Starting OpenRA server."
+/home/openra/lib/openra/server.sh

--- a/.docker/ladder_server/server.sh
+++ b/.docker/ladder_server/server.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Script starts an OpenRA game server
+# Based on https://github.com/OpenRA/OpenRA/blob/bleed/launch-dedicated.sh
+# see https://github.com/OpenRA/OpenRA/wiki/Dedicated for details
+
+Name="${Name:-"Dedicated Server"}"
+Mod="${Mod:-"ra"}"
+ListenPort="${ListenPort:-"1234"}"
+AdvertiseOnline="${AdvertiseOnline:-"True"}"
+Password="${Password:-""}"
+RecordReplays="${RecordReplays:-"False"}"
+
+RequireAuthentication="${RequireAuthentication:-"False"}"
+ProfileIDBlacklist="${ProfileIDBlacklist:-""}"
+ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
+
+EnableSingleplayer="${EnableSingleplayer:-"False"}"
+EnableSyncReports="${EnableSyncReports:-"False"}"
+EnableGeoIP="${EnableGeoIP:-"True"}"
+ShareAnonymizedIPs="${ShareAnonymizedIPs:-"True"}"
+
+SupportDir="${SupportDir:-""}"
+
+# Run loop to restart game server after a game has completed
+while true; do
+  # We rotate maps from the map folder to start with a random pick after each game
+  hash=$(shuf -n1 -e /home/openra/lib/openra/mods/${Mod}/maps/*.oramap)
+  Map=$(./utility.sh $Mod --map-hash $hash)
+
+  # Start the game server
+  mono --debug bin/OpenRA.Server.exe Engine.EngineDir=".." Game.Mod="$Mod" \
+    Server.Name="$Name" \
+    Server.ListenPort="$ListenPort" \
+    Server.AdvertiseOnline="$AdvertiseOnline" \
+    Server.EnableSingleplayer="$EnableSingleplayer" \
+    Server.Password="$Password" \
+    Server.RecordReplays="$RecordReplays" \
+    Server.GeoIPDatabase="$GeoIPDatabase" \
+    Server.RequireAuthentication="$RequireAuthentication" \
+    Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
+    Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
+    Server.EnableSyncReports="$EnableSyncReports" \
+    Server.EnableGeoIP="$EnableGeoIP" \
+    Server.ShareAnonymizedIPs="$ShareAnonymizedIPs" \
+    Server.Map="$Map" \
+    Engine.SupportDir="$SupportDir"
+done

--- a/.docker/ladder_server/srvwrap_minimal.py
+++ b/.docker/ladder_server/srvwrap_minimal.py
@@ -1,0 +1,136 @@
+import os
+import re
+
+_overrides = dict(
+    ra="""
+Player:
+	Shroud:
+		ExploredMapCheckboxEnabled: true
+		ExploredMapCheckboxLocked: true
+		FogCheckboxEnabled: true
+		FogCheckboxLocked: true
+	PlayerResources:
+		DefaultCash: 5000
+		DefaultCashDropdownLocked: true
+	DeveloperMode:
+		CheckboxEnabled: false
+		CheckboxLocked: true
+	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
+		Enabled: true
+		Locked: false
+	LobbyPrerequisiteCheckbox@REUSABLEENGINEERS:
+		Enabled: true
+		Locked: false
+	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Enabled: true
+		Locked: true
+
+World:
+	CrateSpawner:
+		CheckboxEnabled: false
+		CheckboxLocked: true
+	MapBuildRadius:
+		AllyBuildRadiusCheckboxEnabled: true
+		AllyBuildRadiusCheckboxLocked: true
+		BuildRadiusCheckboxEnabled: true
+		BuildRadiusCheckboxLocked: true
+	MapOptions:
+		ShortGameCheckboxEnabled: true
+		ShortGameCheckboxLocked: true
+		TechLevel: unrestricted
+		TechLevelDropdownLocked: true
+		GameSpeed: default
+		GameSpeedDropdownLocked: true
+	MPStartLocations:
+		SeparateTeamSpawnsCheckboxEnabled: true
+		SeparateTeamSpawnsCheckboxLocked: true
+	SpawnMPUnits:
+		StartingUnitsClass: none
+		DropdownLocked: true
+	TimeLimitManager:
+		TimeLimitLocked: true
+""",
+    cnc="""
+Player:
+	Shroud:
+		ExploredMapCheckboxEnabled: true
+		ExploredMapCheckboxLocked: true
+		FogCheckboxEnabled: true
+		FogCheckboxLocked: true
+	PlayerResources:
+		DefaultCash: 7500
+		DefaultCashDropdownLocked: true
+	DeveloperMode:
+		CheckboxEnabled: false
+		CheckboxLocked: true
+	LobbyPrerequisiteCheckbox@GLOBALC17STEALTH
+		Enabled: true
+		Locked: true
+	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
+		Enabled: true
+		Locked: true
+
+World:
+	CrateSpawner:
+		CheckboxEnabled: false
+		CheckboxLocked: true
+	MapBuildRadius:
+		AllyBuildRadiusCheckboxEnabled: true
+		AllyBuildRadiusCheckboxLocked: true
+		BuildRadiusCheckboxEnabled: true
+		BuildRadiusCheckboxLocked: true
+	MapOptions:
+		ShortGameCheckboxEnabled: true
+		ShortGameCheckboxLocked: true
+		TechLevel: unrestricted
+		TechLevelDropdownLocked: true
+		GameSpeed: default
+		GameSpeedDropdownLocked: true
+	MPStartLocations:
+		SeparateTeamSpawnsCheckboxEnabled: true
+		SeparateTeamSpawnsCheckboxLocked: true
+	SpawnMPUnits:
+		StartingUnitsClass: none
+		DropdownLocked: true
+	TimeLimitManager:
+		TimeLimitLocked: true
+""",
+)
+
+
+def _patched_rules(mod, mod_file_path, overrides_rel_path):
+    mod_file_content = ""
+    with open(mod_file_path) as f:
+        for line in f:
+            mod_file_content += line
+            if line.startswith("Rules:"):
+                # Add overrides at the end of the rules to make sure it is
+                # overriden
+                for line in f:
+                    if not line.strip().startswith(f"{mod}|"):
+                        mod_file_content += f"\t{mod}|{overrides_rel_path}\n"
+                        mod_file_content += line
+                        break
+                    mod_file_content += line
+    return mod_file_content
+
+
+def patch():
+    mod = os.getenv("Mod", "ra")
+    mod_base_path = f"/home/openra/lib/openra/mods/{mod}/"
+    overrides_file = "server_settings.yaml"
+    mod_file_path = mod_base_path + "mod.yaml"
+    with open(mod_base_path + overrides_file, "w") as f:
+        f.write(_overrides[mod])
+    mod_file_content = _patched_rules(mod, mod_file_path, overrides_file)
+    with open(mod_file_path, "w") as f:
+        f.write(mod_file_content)
+
+
+def apply_bans(source_file: str):
+    with open(source_file) as bans_file:
+        _banned_profile_re = re.compile(r'^\d+')
+        profile_ids = [int(_banned_profile_re.search(line).group()) for line in bans_file]
+    ban_str = ','.join(str(profile_id) for profile_id in profile_ids)
+    os.environ["ProfileIDBlacklist"] = ban_str
+    print(ban_str)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
+## [2.0.1] - 2022-11-10
+
+### Added
+- [Dockerfile](.docker/ladder_server/Dockerfile) for running OpenRA game servers; building on the base image by [rmoriz](https://github.com/rmoriz/openra-dockerfile) . This adds environment variable handling as well as a custom launch script for the game server that rotates starting maps.
+
 ## [2.0.0] - 2022-10-30
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='oraladder',
-    version='2.0.0',
+    version='2.0.1',
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Added Dockerfile for running OpenRA game servers; building on the base image by [rmoriz](https://github.com/rmoriz/openra-dockerfile) .

This adds environment variable handling as well as a custom launch script for the game server that rotates starting maps.