### PR TITLE
chore: remove unnecessary vertical scrollbar on ladder seasons div

### DIFF
--- a/ladderweb/static/style.css
+++ b/ladderweb/static/style.css
@@ -234,3 +234,7 @@ select, input {
 	color: var(--color_text1);
 	color: #707070;
 }
+
+.season_select_container {
+	overflow: auto !important;
+}


### PR DESCRIPTION
Hey, I noticed the `div.season_select_container` container has the CSS property set to `scroll`. That forces a scrollbar in all directions (see screenshot); the vertical scroll bar is not necessary.

P.S. not sure where that CSS property is defined, I couldn't find it :shrug:  If you have a better solution, fell free to drop this PR and add the change wherever is relevant.

![Screenshot_20230202_165748](https://user-images.githubusercontent.com/68991120/216375619-a8507250-a8aa-4157-a41e-2b341997bd61.png)
