### PR TITLE
Align development and production

### DIFF
--- a/.docker/Dockerfile_ladder
+++ b/.docker/Dockerfile_ladder
@@ -1,17 +1,6 @@
 FROM oraladder/base:latest
 
-# https://github.com/chartjs/Chart.js/releases/latest
-ENV CHART_JS_VERSION="2.9.3"
-# https://github.com/jquery/jquery/releases/latest
-ENV JQUERY_VERSION="3.6.0"
-# https://github.com/DataTables/DataTables/releases/latest
-ENV DATATABLES_VERSION="1.10.24"
-
-RUN cd ladderweb/static/ \
-    && curl -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/${CHART_JS_VERSION}/Chart.min.css -o Chart.min.css \
-    && curl -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/${CHART_JS_VERSION}/Chart.bundle.min.js -o Chart.bundle.min.js \
-    && curl -L https://cdn.datatables.net/v/dt/dt-${DATATABLES_VERSION}/datatables.min.js -o datatables.min.js \
-    && curl -L https://code.jquery.com/jquery-${JQUERY_VERSION}.min.js -o jquery.min.js
+RUN make download-static
 
 RUN python3 -m venv venv/
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ ladderweb/static/datatables.min.js:
 ladderweb/static/jquery.min.js:
 	$(CURL) -s -L https://code.jquery.com/jquery-$(JQUERY_VERSION).min.js -o $@
 
+download-static: $(LADDER_STATIC)
+
 $(LADDER_DATABASES): instance
 	([ -f $@ ] ||  $(VENV)/bin/ora-ladder -d $@)
 
@@ -99,4 +101,4 @@ $(VENV):
 	$(PYTHON) -m venv $@
 	$(VENV)/bin/python -m pip install -e .
 
-.PHONY: ladderdev initladderdev wheel clean mappacks ragldev initragldev test
+.PHONY: ladderdev initladderdev wheel clean mappacks ragldev initragldev test download-static

--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,16 @@ ladderdev: initladderdev
 initladderdev: $(VENV) $(LADDER_STATIC) $(LADDER_DATABASES)
 
 ladderweb/static/Chart.min.css:
-	$(CURL) -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/$(CHART_JS_VERSION)/Chart.min.css -o $@
+	$(CURL) -s -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/$(CHART_JS_VERSION)/Chart.min.css -o $@
 
 ladderweb/static/Chart.bundle.min.js:
-	$(CURL) -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/$(CHART_JS_VERSION)/Chart.bundle.min.js -o $@
+	$(CURL) -s -L https://cdnjs.cloudflare.com/ajax/libs/Chart.js/$(CHART_JS_VERSION)/Chart.bundle.min.js -o $@
 
 ladderweb/static/datatables.min.js:
-	$(CURL) -L https://cdn.datatables.net/v/dt/dt-$(DATATABLES_VERSION)/datatables.min.js -o $@
+	$(CURL) -s -L https://cdn.datatables.net/v/dt/dt-$(DATATABLES_VERSION)/datatables.min.js -o $@
 
 ladderweb/static/jquery.min.js:
-	$(CURL) -L https://code.jquery.com/jquery-$(JQUERY_VERSION).min.js -o $@
+	$(CURL) -s -L https://code.jquery.com/jquery-$(JQUERY_VERSION).min.js -o $@
 
 $(LADDER_DATABASES): instance
 	([ -f $@ ] ||  $(VENV)/bin/ora-ladder -d $@)


### PR DESCRIPTION
by defining the JavaScript imports only once. Also silence cURL for less noise in the build logs.